### PR TITLE
fix: use .id for API validation, remove broken jlpt-pro from PINNED

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,16 +847,22 @@
     }
     async function loadPinnedRepos() {
       try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
         const results = await Promise.all(
           PINNED.map(name =>
             fetch(`https://api.github.com/repos/shanewas/${name}`, {
-              headers: { 'Accept': 'application/vnd.github.v3+json' }
-            }).then(r => r.json())
+              headers: { 'Accept': 'application/vnd.github.v3+json' },
+              signal: controller.signal
+            })
+              .then(r => r.json())
+              .catch(() => ({ id: null }))
           )
         );
-        // Check if API returned valid data (not rate limit error)
-        if (results[0] && results[0].name) {
-          renderRepos(results);
+        clearTimeout(timeout);
+        const valid = results.filter(r => r && r.id);
+        if (valid.length > 0) {
+          renderRepos(valid);
         } else {
           renderRepos(FALLBACK);
         }


### PR DESCRIPTION
## Problem

 is a **private** repo. GitHub API returns  for private repos without auth.

The old validation:


This caused the **entire projects section** to fall back to FALLBACK whenever jlpt-pro was in the PINNED array — showing the wrong repos instead of the 5 valid ones.

## Fix

1. **Remove jlpt-pro from PINNED** — it's private, can't show it publicly anyway
2. **Change validation:  → ** —  is present on all valid repo responses, absent on error/404 objects
3. **Filter valid repos**:  — show whichever repos are valid, skip broken ones
4. **AbortController + 8s timeout** — prevent hanging fetches
5. **Remove jlpt-pro from FALLBACK too** — doesn't exist publicly

Now if 5 out of 6 PINNED repos are valid, those 5 get shown correctly.