### PR TITLE
fix: replace skeleton loaders with static HTML project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,21 +649,60 @@
           </a>
         </div>
         <div id="projects-grid" class="project-grid">
-          <!-- Skeleton loaders -->
-          <div class="project-card skeleton-card" style="min-height:180px; animation: pulse 1.5s infinite;">
-            <div style="height:1rem; width:60%; background:rgba(255,255,255,0.08); border-radius:.3rem; margin-bottom:1rem;"></div>
-            <div style="height:.75rem; width:90%; background:rgba(255,255,255,0.05); border-radius:.3rem; margin-bottom:.5rem;"></div>
-            <div style="height:.75rem; width:70%; background:rgba(255,255,255,0.05); border-radius:.3rem;"></div>
+          <div class="project-card">
+            <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;">
+              <i class="bx bx-git-repo-forked" style="color:var(--text-muted);"></i>
+              <h4 style="margin:0;">ValidationEngine</h4>
+            </div>
+            <p>@shanewas/form-validation — powerful form validation engine for Node.js and browsers.</p>
+            <div class="project-tags" style="margin-bottom:auto;">
+              <span class="project-tag"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#f1e05a;margin-right:.4rem;vertical-align:middle;"></span>JavaScript</span>
+            </div>
+            <a href="https://github.com/shanewas/ValidationEngine" target="_blank" style="font-size:.82rem;color:var(--accent);margin-top:1rem;display:inline-block;">View on GitHub →</a>
           </div>
-          <div class="project-card skeleton-card" style="min-height:180px; animation: pulse 1.5s infinite .2s;">
-            <div style="height:1rem; width:50%; background:rgba(255,255,255,0.08); border-radius:.3rem; margin-bottom:1rem;"></div>
-            <div style="height:.75rem; width:85%; background:rgba(255,255,255,0.05); border-radius:.3rem; margin-bottom:.5rem;"></div>
-            <div style="height:.75rem; width:65%; background:rgba(255,255,255,0.05); border-radius:.3rem;"></div>
+          <div class="project-card">
+            <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;">
+              <i class="bx bx-git-repo-forked" style="color:var(--text-muted);"></i>
+              <h4 style="margin:0;">payflow</h4>
+            </div>
+            <p>Full-stack payment system: Node.js, Express, Stripe API, PostgreSQL, React. JWT auth, webhooks, refunds, Docker.</p>
+            <div class="project-tags" style="margin-bottom:auto;">
+              <span class="project-tag"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#f1e05a;margin-right:.4rem;vertical-align:middle;"></span>JavaScript</span>
+            </div>
+            <a href="https://github.com/shanewas/payflow" target="_blank" style="font-size:.82rem;color:var(--accent);margin-top:1rem;display:inline-block;">View on GitHub →</a>
           </div>
-          <div class="project-card skeleton-card" style="min-height:180px; animation: pulse 1.5s infinite .4s;">
-            <div style="height:1rem; width:55%; background:rgba(255,255,255,0.08); border-radius:.3rem; margin-bottom:1rem;"></div>
-            <div style="height:.75rem; width:80%; background:rgba(255,255,255,0.05); border-radius:.3rem; margin-bottom:.5rem;"></div>
-            <div style="height:.75rem; width:60%; background:rgba(255,255,255,0.05); border-radius:.3rem;"></div>
+          <div class="project-card">
+            <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;">
+              <i class="bx bx-git-repo-forked" style="color:var(--text-muted);"></i>
+              <h4 style="margin:0;">StructProbe</h4>
+            </div>
+            <p>C++ / libclang utility that parses C/C++ headers and prints struct sizes and field offsets. Win32 SDK headers on Linux.</p>
+            <div class="project-tags" style="margin-bottom:auto;">
+              <span class="project-tag"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#f34b7d;margin-right:.4rem;vertical-align:middle;"></span>C++</span>
+            </div>
+            <a href="https://github.com/shanewas/StructProbe" target="_blank" style="font-size:.82rem;color:var(--accent);margin-top:1rem;display:inline-block;">View on GitHub →</a>
+          </div>
+          <div class="project-card">
+            <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;">
+              <i class="bx bx-git-repo-forked" style="color:var(--text-muted);"></i>
+              <h4 style="margin:0;">tunnelfox</h4>
+            </div>
+            <p>Privacy desktop browser routing all traffic through an SSH SOCKS5 tunnel. PyQt6 + Chromium, dark UI, tunnel health monitoring.</p>
+            <div class="project-tags" style="margin-bottom:auto;">
+              <span class="project-tag"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#3572A5;margin-right:.4rem;vertical-align:middle;"></span>Python</span>
+            </div>
+            <a href="https://github.com/shanewas/tunnelfox" target="_blank" style="font-size:.82rem;color:var(--accent);margin-top:1rem;display:inline-block;">View on GitHub →</a>
+          </div>
+          <div class="project-card">
+            <div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem;">
+              <i class="bx bx-git-repo-forked" style="color:var(--text-muted);"></i>
+              <h4 style="margin:0;">posix-ipc-dotnet</h4>
+            </div>
+            <p>.NET library for System V shared memory and semaphores on Linux (x64, glibc). Low-latency IPC between processes.</p>
+            <div class="project-tags" style="margin-bottom:auto;">
+              <span class="project-tag"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#178600;margin-right:.4rem;vertical-align:middle;"></span>C#</span>
+            </div>
+            <a href="https://github.com/shanewas/posix-ipc-dotnet" target="_blank" style="font-size:.82rem;color:var(--accent);margin-top:1rem;display:inline-block;">View on GitHub →</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Projects section now shows 5 project cards directly in HTML — no JavaScript required to display them.